### PR TITLE
adding v2 to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-co-op/gocron-gorm-lock
+module github.com/go-co-op/gocron-gorm-lock/v2
 
 go 1.22
 


### PR DESCRIPTION
### What does this do?
 Fixing go.mod

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes

@JohnRoesler it seems that since I did not update go.mod to add `/v2` to the module name, people can't download the dependency. In this PR I added the v2. But I am afraid I messed it up with the branching, since, in theory, master should have continued with the v1, and I should have created a v2 branch for the v2 of the locker.

To be honest I don't think I need to _keep supporting_ v1, so, if possible, I would like that the **master branch now points only to the v2**. But what do you think? shall we try to make master -> v2, or shall we follow the approach of master -> v1, and v2 -> v2.
